### PR TITLE
Fixed slicing issue

### DIFF
--- a/qontrol.py
+++ b/qontrol.py
@@ -777,8 +777,8 @@ class _ChannelVector(object):
 			else:
 				vs = [value] * len(ks)
 			
-			for k in ks:
-				self[k] = vs[k]
+			for i,k in enumerate(ks):
+				self[k] = vs[i]
 		else:
 			# Handle normal key
 			if self.set_handle is not None:


### PR DESCRIPTION
The list slicing of ChannelVector doesn't work properly. While the` __get_item__` method always works, setting new elements only works when the slice starts from zero and the step of the slice is exactly 1.
The problem seems to be the way you handle the vs list: this list should be indexed independently with respect to slice of the channels passed to the ​`__set_item__` methods. For this reason, I believe that the change I propose is the simplest and least-invasive solution.